### PR TITLE
update resource

### DIFF
--- a/deploy/values.yml
+++ b/deploy/values.yml
@@ -38,8 +38,8 @@ podAnnotations:
 
 resources:
   limits:
-    cpu: 0.25
-    memory: 512Mi
+    cpu: 0.15
+    memory: 192Mi
   requests:
     cpu: 0.1
     memory: 128Mi


### PR DESCRIPTION
limits supposed to be 1.5 * requests when you have HPA 75% enabled. otherwise the CPU and memory will be all wasted.

** this repo does not have a branch protection so I pushed [1] into master before. But I just cancelled the deployment did not let the deployment run and change the file back [2]. the change is to do with resources.

[1] https://github.com/skybase-int/ecosystem-dashboard/actions/runs/10694609028
[2] https://github.com/skybase-int/ecosystem-dashboard/actions/runs/10694636627